### PR TITLE
feat: events

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def strategy(strategist, keeper, vault, Strategy, gov):
     # Fix k error
     pairs = [strategy.ethCrvPair(), strategy.ethYveCrvPair(), strategy.ethUsdcPair()]
     for pair in pairs:
-        Contract.from_explorer(pair, owner=strategist).sync()
+        Contract(pair, owner=strategist).sync()
     yield strategy
 
 

--- a/tests/test_profitable.py
+++ b/tests/test_profitable.py
@@ -1,6 +1,6 @@
 import brownie
 from helpers import showBalances
-from brownie import Contract
+from brownie import Contract, Wei
 import time
 
 def test_profitable_harvest(
@@ -32,11 +32,11 @@ def test_profitable_harvest(
     # Done to fix the UniswapV2: K issue
     pairs = [strategy.ethCrvPair(), strategy.ethYveCrvPair(), strategy.ethUsdcPair()]
     for pair in pairs:
-        Contract.from_explorer(pair, owner=strategist).sync()
+        Contract(pair, owner=strategist).sync()
 
     # Simulate a claim by sending some 3Crv to the strategy before harvest
-    crv3.transfer(strategy, 1e18, {"from": whale_3crv})
-    strategy.harvest()
+    crv3.transfer(strategy, Wei("10 ether"), {"from": whale_3crv})
+    tx = strategy.harvest()
     print("\n\n~~After Harvest #2~~")
     showBalances(token, vault, strategy, yveCrv, weth, usdc, crv3)
     assert token.balanceOf(strategy.address) > amount


### PR DESCRIPTION
Run with `brownie test tests/test_profitable.py -s -I`
and when it fails run:
```
>>> tx.events
{'InsideClaimable': [OrderedDict()], 'Transfer': [OrderedDict([('from', '0xc5bDdf9843308380375a611c18B50Fb9341f502A'), ('to', '0xd1C326825A96B1098b3C4bB18edE6D2402aDEF8b'), ('value', 0)]), OrderedDict([('from', '0xd1C326825A96B1098b3C4bB18edE6D2402aDEF8b'), ('to', '0x0000000000000000000000000000000000000000'), ('value', 10000000000000000000)]), OrderedDict([('from', '0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7'), ('to', '0xd1C326825A96B1098b3C4bB18edE6D2402aDEF8b'), ('value', 10145845)])], 'AfterClaim': [OrderedDict()], 'RemoveLiquidityOne': [OrderedDict([('provider', '0xd1C326825A96B1098b3C4bB18edE6D2402aDEF8b'), ('token_amount', 10000000000000000000), ('coin_amount', 10145845)])], 'AfterWithdraw': [OrderedDict()], 'UsdcBalance': [OrderedDict([('usdcBalance', 10145845)])], 'ShouldMint': [OrderedDict([('amount', 10145845)])], 'PairLog': [OrderedDict([('value1', 189710461606157), ('value2', 118006496998872349102909)]), OrderedDict([('value1', 4282865238458559534902), ('value2', 2820551140270792339235143)]), OrderedDict([('value1', 7817429160814320428286), ('value2', 6141810540251225806242013)])], 'AmountOutRet': [OrderedDict([('ret', 0)])]}
```

Last event is generated by `emit AmountOutRet(projectedWeth);`

